### PR TITLE
Fix participant display and Android date picker

### DIFF
--- a/src/types/session.ts
+++ b/src/types/session.ts
@@ -20,9 +20,10 @@ export type SessionParticipant = {
   session_id: number;
   user_id: number;
   character_id?: string;
+  role?: 'master' | 'player' | 'spectator' | string;
   joined_at: string;
   left_at?: string;
-  is_online: boolean;
+  is_online: boolean | number | string;
   last_seen: string;
 };
 
@@ -31,7 +32,7 @@ export type SessionPresence = {
   session_id: number;
   user_id: number;
   character_id?: string;
-  is_online: boolean;
+  is_online: boolean | number | string;
   last_seen: string;
   joined_at: string;
   left_at?: string;


### PR DESCRIPTION
## Summary
- ensure the active session participant list recognises the MJ, normalises online state and updates labels for the connected user
- extend session participant typing to include roles and non-boolean online flags used by the backend
- handle Android date/time selection with the native DateTimePickerAndroid flow to avoid the dismiss error

## Testing
- npx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68cd8af35c88832e9da929717e3d692f