### PR TITLE
Add Ably realtime UI components for chat, images, and draws

### DIFF
--- a/Docs/Realtime_ABLY.md
+++ b/Docs/Realtime_ABLY.md
@@ -1,0 +1,121 @@
+# Intégration ABLY temps réel
+
+Ce répertoire introduit des composants UI prêts à l'emploi qui s'appuient sur l'API [Ably Realtime](https://ably.com/) pour la messagerie instantanée, le partage d'images et la diffusion des tirages de jeu. Aucune modification n'est apportée aux écrans actuels : il suffit d'instancier les composants dans les vues existantes après avoir fourni un client Ably.
+
+## 1. Initialiser le client Ably
+
+1. **Déclarer la clé API** : Expo expose automatiquement les variables d'environnement commençant par `EXPO_PUBLIC_`. Ajoute ta clé dans un fichier `.env` (non versionné) :
+
+   ```bash
+   # .env.local
+   EXPO_PUBLIC_ABLY_API_KEY=xxxxx:yyyyyy
+   ```
+
+   Ou bien renseigne `EXPO_PUBLIC_ABLY_API_KEY` dans ton environnement CI/CD.
+
+2. **Lire la clé côté app** : le provider `AblyProvider` s'occupe d'initialiser `Ably.Realtime`. Place-le dans `App.tsx` (ou dans le navigator ciblé) :
+
+   ```tsx
+   import { AblyProvider } from '@/context/AblyProvider';
+
+   const ABLY_API_KEY = process.env.EXPO_PUBLIC_ABLY_API_KEY;
+
+   export default function App() {
+     return (
+       <AblyProvider apiKey={ABLY_API_KEY} clientId={currentPlayerId}>
+         {/* le reste de l'application */}
+       </AblyProvider>
+     );
+   }
+   ```
+
+   - `apiKey` est obligatoire (ou fournis `authUrl` pour la token auth Ably).
+   - `clientId` est optionnel mais utile pour identifier les messages/presence.
+   - Le provider expose également `useAblyConnectionState()` pour suivre l'état (`connected`, `disconnected`, etc.) si besoin.
+
+3. **Sécurité** : ne commite jamais la clé API. Utilise les variables d'environnement Expo (`EXPO_PUBLIC_*`) ou un proxy d'authentification Ably (`authUrl`).
+
+## 2. Hooks et utilitaires
+
+- `useAblyChannel(channelName, options)` gère l'attachement au canal, les abonnements aux events (`events`), et expose deux helpers :
+  - `publish(eventName, data)` renvoie une `Promise` qui se résout quand le message est accepté par Ably.
+  - `fetchHistory(params)` récupère l'historique (`channel.history`).
+
+Toutes les opérations asynchrones sont encapsulées pour éviter de manipuler les callbacks Ably directement dans les composants UI.
+
+## 3. Composants disponibles
+
+### `RealtimeChat`
+
+| Prop              | Description |
+|-------------------|-------------|
+| `channelName`     | Nom du canal Ably (ex. `scenario:123:chat`). |
+| `currentUser`     | `{ id: string; name: string; }` utilisé pour annoter les messages envoyés. |
+| `messageLimit`    | Nombre maximum de messages conservés en mémoire (défaut : 100). |
+| `placeholder`     | Texte du champ de saisie. |
+| `emptyStateText`  | Texte d'état vide. |
+
+Fonctionnalités :
+- Récupère l'historique récent (`channel.history`).
+- Déduplication des messages grâce à l'`id` embarqué dans le payload (`uuid`).
+- Style simple (bulles gauche/droite) adaptable via un wrapper externe.
+
+### `RealtimeImageBroadcast`
+
+| Prop              | Description |
+|-------------------|-------------|
+| `channelName`     | Canal Ably utilisé (ex. `scenario:123:images`). |
+| `currentUser`     | Identité du MJ / joueur. |
+| `isGameMaster`    | Active les contrôles d'émission (URL + picker). |
+| `historyLimit`    | Nombre de diffusions mémorisées (défaut : 10). |
+| `emptyStateText`  | Texte affiché si aucune image n'a été reçue. |
+
+Fonctionnalités :
+- Le MJ peut diffuser soit une URL d'image publique, soit un fichier de la galerie (encodé en base64).
+- Les messages incluent `caption`, `mimeType`, `senderName` pour enrichir l'affichage.
+- Un mini carrousel horizontal liste les diffusions précédentes.
+- Attention à la taille des images encodées : Ably limite les messages à ~64 Ko. Un avertissement s'affiche quand l'image dépasse ~60 Ko.
+
+### `RealtimeDrawFeed`
+
+| Prop              | Description |
+|-------------------|-------------|
+| `channelName`     | Canal Ably (`scenario:123:draws`). |
+| `currentUser`     | Joueur courant. |
+| `historyLimit`    | Taille du flux partagé (défaut : 50). |
+| `diceOptions`     | Liste personnalisable des dés proposés (défaut : d4 → d100). |
+| `emptyStateText`  | Texte affiché si aucun tirage. |
+
+Fonctionnalités :
+- Gestion d'un nombre de dés (1 → 10), modificateur numérique et étiquette du tirage.
+- Calcul du total + détails des jets, historisés et synchronisés avec les autres joueurs.
+- Mise en avant des tirages effectués par l'utilisateur courant.
+
+## 4. Bonnes pratiques
+
+- **Nomenclature des canaux** : garde une structure cohérente (`scenario:{id}:{feature}`) pour éviter les collisions.
+- **Déconnexion propre** : `AblyProvider` ferme la connexion lors de l'unmount et `useAblyChannel` détache les canaux pour éviter les fuites.
+- **Test** : pour vérifier rapidement, tu peux instancier les composants dans un écran de test et lancer deux sessions Expo (web + mobile) avec la même clé API.
+- **Évolution** : les composants sont volontairement découplés. Si tu as besoin d'une logique supplémentaire (moderation, logs, etc.), tu peux dériver le hook `useAblyChannel`.
+
+## 5. Exemple d'assemblage
+
+```tsx
+import { RealtimeChat, RealtimeImageBroadcast, RealtimeDrawFeed } from '@/components/realtime';
+
+function ScenarioRealtimePane({ scenarioId, currentUser, isGameMaster }: Props) {
+  return (
+    <>
+      <RealtimeChat channelName={`scenario:${scenarioId}:chat`} currentUser={currentUser} />
+      <RealtimeImageBroadcast
+        channelName={`scenario:${scenarioId}:images`}
+        currentUser={currentUser}
+        isGameMaster={isGameMaster}
+      />
+      <RealtimeDrawFeed channelName={`scenario:${scenarioId}:draws`} currentUser={currentUser} />
+    </>
+  );
+}
+```
+
+En résumé : installe la clé Ably via une variable d'environnement Expo, entoure ton application avec `AblyProvider`, puis insère les composants dans les écrans où tu veux la synchronisation temps réel.

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@react-navigation/native": "^7.1.14",
         "@react-navigation/native-stack": "^7.3.21",
         "@tanstack/react-query": "^5.83.0",
+        "ably": "^2.13.0",
         "expo": "53.0.22",
         "expo-av": "^15.1.7",
         "expo-brightness": "~13.1.4",
@@ -67,6 +68,15 @@
         "graphql": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@ably/msgpack-js": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@ably/msgpack-js/-/msgpack-js-0.4.1.tgz",
+      "integrity": "sha512-Sjxj6SOr17hExAVrsycN7u6oV4PhZcK7Z2S8dM71CH/butgO47cSo/TL6FJPCXUyDAzKkOWjMUpJGyZkEpyu4Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bops": "^1.0.1"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -3584,6 +3594,18 @@
       "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
       "license": "MIT"
     },
+    "node_modules/@sindresorhus/is": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
+      "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
     "node_modules/@sinonjs/commons": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
@@ -3600,6 +3622,18 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
+      }
+    },
+    "node_modules/@szmarczak/http-timer": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
+      "integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
+      "license": "MIT",
+      "dependencies": {
+        "defer-to-connect": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@tanstack/query-core": {
@@ -3669,6 +3703,18 @@
         "@babel/types": "^7.20.7"
       }
     },
+    "node_modules/@types/cacheable-request": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
+      "integrity": "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-cache-semantics": "*",
+        "@types/keyv": "^3.1.4",
+        "@types/node": "*",
+        "@types/responselike": "^1.0.0"
+      }
+    },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.9",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.9.tgz",
@@ -3682,6 +3728,12 @@
       "version": "2.0.46",
       "resolved": "https://registry.npmjs.org/@types/hammerjs/-/hammerjs-2.0.46.tgz",
       "integrity": "sha512-ynRvcq6wvqexJ9brDMS4BnBLzmr0e14d6ZJTEShTBWKymQiHwlAyGu0ZPEFI2Fh1U53F7tN9ufClWM5KvqkKOw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/http-cache-semantics": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
+      "integrity": "sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA==",
       "license": "MIT"
     },
     "node_modules/@types/istanbul-lib-coverage": {
@@ -3708,6 +3760,15 @@
         "@types/istanbul-lib-report": "*"
       }
     },
+    "node_modules/@types/keyv": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
+      "integrity": "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/node": {
       "version": "24.0.14",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.14.tgz",
@@ -3725,6 +3786,15 @@
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/responselike": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz",
+      "integrity": "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/stack-utils": {
@@ -3784,6 +3854,35 @@
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/ably": {
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/ably/-/ably-2.13.0.tgz",
+      "integrity": "sha512-fgrzWlUWRCOCqCNq1szMZNsa/VXYwS3DParDpMuhCBPxmsDL2Y1fMpppfHtQiFRvNFcInY9bPQXuPFjJpmqSHw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ably/msgpack-js": "^0.4.0",
+        "dequal": "^2.0.3",
+        "fastestsmallesttextencoderdecoder": "^1.0.22",
+        "got": "^11.8.5",
+        "ulid": "^2.3.0",
+        "ws": "^8.17.1"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/abort-controller": {
@@ -4341,6 +4440,25 @@
       "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
       "license": "ISC"
     },
+    "node_modules/bops": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bops/-/bops-1.0.1.tgz",
+      "integrity": "sha512-qCMBuZKP36tELrrgXpAfM+gHzqa0nLsWZ+L37ncsb8txYlnAoxOPpVp+g7fK0sGkMXfA0wl8uQkESqw3v4HNag==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "1.0.2",
+        "to-utf8": "0.0.1"
+      }
+    },
+    "node_modules/bops/node_modules/base64-js": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.0.2.tgz",
+      "integrity": "sha512-ZXBDPMt/v/8fsIqn+Z5VwrhdR6jVka0bYobHdGia0Nxi7BJ9i/Uvml3AocHIBtIIBhZjBw5MR0aR4ROs/8+SNg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/bplist-creator": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/bplist-creator/-/bplist-creator-0.1.0.tgz",
@@ -4461,6 +4579,48 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/cacheable-lookup": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
+      "integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.6.0"
+      }
+    },
+    "node_modules/cacheable-request": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.4.tgz",
+      "integrity": "sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==",
+      "license": "MIT",
+      "dependencies": {
+        "clone-response": "^1.0.2",
+        "get-stream": "^5.1.0",
+        "http-cache-semantics": "^4.0.0",
+        "keyv": "^4.0.0",
+        "lowercase-keys": "^2.0.0",
+        "normalize-url": "^6.0.1",
+        "responselike": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cacheable-request/node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/call-bind-apply-helpers": {
@@ -4748,6 +4908,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/clone-response": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
+      "integrity": "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/color": {
@@ -5122,6 +5294,33 @@
         "node": ">=0.10"
       }
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/decompress-response/node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/deep-extend": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
@@ -5152,6 +5351,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/defer-to-connect": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
+      "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/define-lazy-prop": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
@@ -5168,6 +5376,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/destroy": {
@@ -5337,6 +5554,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
       }
     },
     "node_modules/entities": {
@@ -5943,6 +6169,12 @@
         "fxparser": "src/cli/cli.js"
       }
     },
+    "node_modules/fastestsmallesttextencoderdecoder": {
+      "version": "1.0.22",
+      "resolved": "https://registry.npmjs.org/fastestsmallesttextencoderdecoder/-/fastestsmallesttextencoderdecoder-1.0.22.tgz",
+      "integrity": "sha512-Pb8d48e+oIuY4MaM64Cd7OW1gt4nxCHs7/ddPPZ/Ic3sg8yVGM7O9wDvZ7us6ScaUupzM+pfBolwtYhN1IxBIw==",
+      "license": "CC0-1.0"
+    },
     "node_modules/fastq": {
       "version": "1.19.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
@@ -6249,6 +6481,31 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/got": {
+      "version": "11.8.6",
+      "resolved": "https://registry.npmjs.org/got/-/got-11.8.6.tgz",
+      "integrity": "sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/is": "^4.0.0",
+        "@szmarczak/http-timer": "^4.0.5",
+        "@types/cacheable-request": "^6.0.1",
+        "@types/responselike": "^1.0.0",
+        "cacheable-lookup": "^5.0.3",
+        "cacheable-request": "^7.0.2",
+        "decompress-response": "^6.0.0",
+        "http2-wrapper": "^1.0.0-beta.5.2",
+        "lowercase-keys": "^2.0.0",
+        "p-cancelable": "^2.0.0",
+        "responselike": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/got?sponsor=1"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -6345,6 +6602,12 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "license": "ISC"
     },
+    "node_modules/http-cache-semantics": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/http-errors": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
@@ -6368,6 +6631,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/http2-wrapper": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
+      "integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
+      "license": "MIT",
+      "dependencies": {
+        "quick-lru": "^5.1.1",
+        "resolve-alpn": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=10.19.0"
       }
     },
     "node_modules/https-proxy-agent": {
@@ -6974,6 +7250,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "license": "MIT"
+    },
     "node_modules/json-parse-better-errors": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
@@ -7005,6 +7287,15 @@
       "license": "MIT",
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
       }
     },
     "node_modules/kleur": {
@@ -7601,6 +7892,15 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/lowercase-keys": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+      "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -8095,6 +8395,15 @@
         "node": ">=4"
       }
     },
+    "node_modules/mimic-response": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/minimatch": {
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
@@ -8269,6 +8578,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/normalize-url": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
+      "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/npm-package-arg": {
@@ -8535,6 +8856,15 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/p-cancelable": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
+      "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/p-limit": {
@@ -9079,6 +9409,16 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
     },
+    "node_modules/pump": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
+      "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -9333,6 +9673,18 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/quick-lru": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/range-parser": {
       "version": "1.2.1",
@@ -10012,6 +10364,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/resolve-alpn": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
+      "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
+      "license": "MIT"
+    },
     "node_modules/resolve-from": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
@@ -10034,6 +10392,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/responselike": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
+      "integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
+      "license": "MIT",
+      "dependencies": {
+        "lowercase-keys": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/restore-cursor": {
@@ -11163,6 +11533,12 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/to-utf8": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/to-utf8/-/to-utf8-0.0.1.tgz",
+      "integrity": "sha512-zks18/TWT1iHO3v0vFp5qLKOG27m67ycq/Y7a7cTiRuUNlc4gf3HGnkRgMv0NyhnfTamtkYBJl+YeD1/j07gBQ==",
+      "license": "MIT"
+    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -11221,6 +11597,15 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/ulid": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/ulid/-/ulid-2.4.0.tgz",
+      "integrity": "sha512-fIRiVTJNcSRmXKPZtGzFQv9WRrZ3M9eoptl/teFJvjOzmpU+/K/JH6HZ8deBfb5vMEpicJcLn7JmvdknlMq7Zg==",
+      "license": "MIT",
+      "bin": {
+        "ulid": "bin/cli.js"
       }
     },
     "node_modules/undici": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@react-navigation/native": "^7.1.14",
     "@react-navigation/native-stack": "^7.3.21",
     "@tanstack/react-query": "^5.83.0",
+    "ably": "^2.13.0",
     "expo": "53.0.22",
     "expo-av": "^15.1.7",
     "expo-brightness": "~13.1.4",

--- a/src/components/realtime/RealtimeChat.tsx
+++ b/src/components/realtime/RealtimeChat.tsx
@@ -1,0 +1,307 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { FlatList, StyleSheet, Text, TextInput, View, Pressable } from 'react-native';
+import type { ListRenderItem } from 'react-native';
+import type { Message } from 'ably';
+import { v4 as uuidv4 } from 'uuid';
+
+import { useAblyChannel } from '@/hooks/useAblyChannel';
+import type { ChatMessage, ChatMessagePayload, RealtimeIdentity } from '@/types/realtime';
+
+const CHAT_EVENT = 'chat-message';
+
+interface RealtimeChatProps {
+  channelName: string;
+  currentUser: RealtimeIdentity;
+  /** Maximum number of chat messages kept in memory. */
+  messageLimit?: number;
+  placeholder?: string;
+  emptyStateText?: string;
+}
+
+const formatTimestamp = (timestamp: number) => {
+  const date = new Date(timestamp);
+  const hours = date.getHours().toString().padStart(2, '0');
+  const minutes = date.getMinutes().toString().padStart(2, '0');
+  return `${hours}:${minutes}`;
+};
+
+const parseChatMessage = (message: Message): ChatMessage | null => {
+  if (message.name && message.name !== CHAT_EVENT) {
+    return null;
+  }
+
+  const rawData = message.data as Partial<ChatMessagePayload> | string | null | undefined;
+
+  let payload: Partial<ChatMessagePayload> | null = null;
+
+  if (typeof rawData === 'string') {
+    payload = { text: rawData };
+  } else if (rawData && typeof rawData === 'object') {
+    payload = rawData;
+  }
+
+  if (!payload?.text) {
+    return null;
+  }
+
+  const fallbackId =
+    payload.id ??
+    message.id ??
+    (message.timestamp ? `${message.timestamp}-${message.connectionId ?? 'local'}` : undefined) ??
+    uuidv4();
+
+  return {
+    id: fallbackId,
+    text: payload.text,
+    senderId: payload.senderId ?? message.clientId ?? 'unknown',
+    senderName: payload.senderName ?? payload.senderId ?? message.clientId ?? 'Anonyme',
+    timestamp: message.timestamp ?? Date.now(),
+  };
+};
+
+export default function RealtimeChat({
+  channelName,
+  currentUser,
+  messageLimit = 100,
+  placeholder = 'Écrire un message…',
+  emptyStateText = 'Aucun message pour le moment.',
+}: RealtimeChatProps) {
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [draft, setDraft] = useState('');
+  const [isSending, setIsSending] = useState(false);
+
+  const handleIncomingMessage = useCallback(
+    (message: Message) => {
+      const parsed = parseChatMessage(message);
+      if (!parsed) {
+        return;
+      }
+
+      setMessages((previous) => {
+        const existingIndex = previous.findIndex((item) => item.id === parsed.id);
+        const nextMessages = existingIndex >= 0 ? [...previous] : [...previous, parsed];
+
+        if (existingIndex >= 0) {
+          nextMessages[existingIndex] = parsed;
+        }
+
+        nextMessages.sort((a, b) => a.timestamp - b.timestamp);
+
+        if (nextMessages.length > messageLimit) {
+          return nextMessages.slice(-messageLimit);
+        }
+
+        return nextMessages;
+      });
+    },
+    [messageLimit],
+  );
+
+  const { channel, publish, fetchHistory } = useAblyChannel(channelName, {
+    events: CHAT_EVENT,
+    onMessage: handleIncomingMessage,
+  });
+
+  useEffect(() => {
+    if (!channel) {
+      return;
+    }
+
+    let isMounted = true;
+
+    const loadHistory = async () => {
+      try {
+        const page = await fetchHistory({ limit: messageLimit });
+        if (!page || !isMounted) {
+          return;
+        }
+
+        const history = page.items
+          .map((item) => parseChatMessage(item))
+          .filter((item): item is ChatMessage => Boolean(item))
+          .sort((a, b) => a.timestamp - b.timestamp);
+
+        setMessages(history.slice(-messageLimit));
+      } catch (error) {
+        console.warn('Unable to fetch chat history from Ably', error);
+      }
+    };
+
+    loadHistory();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [channel, fetchHistory, messageLimit]);
+
+  const sendMessage = useCallback(async () => {
+    const trimmed = draft.trim();
+
+    if (!trimmed || isSending) {
+      return;
+    }
+
+    setIsSending(true);
+
+    const payload: ChatMessagePayload = {
+      id: uuidv4(),
+      text: trimmed,
+      senderId: currentUser.id,
+      senderName: currentUser.name,
+    };
+
+    try {
+      await publish(CHAT_EVENT, payload);
+      setDraft('');
+    } catch (error) {
+      console.warn('Unable to publish chat message to Ably', error);
+    } finally {
+      setIsSending(false);
+    }
+  }, [currentUser.id, currentUser.name, draft, isSending, publish]);
+
+  const renderItem = useCallback<ListRenderItem<ChatMessage>>(
+    ({ item }) => {
+      const isOwnMessage = item.senderId === currentUser.id;
+
+      return (
+        <View
+          style={[
+            styles.messageBubble,
+            isOwnMessage ? styles.messageBubbleSelf : styles.messageBubbleOther,
+          ]}
+        >
+          <Text style={styles.messageSender}>{item.senderName}</Text>
+          <Text style={styles.messageText}>{item.text}</Text>
+          <Text style={styles.messageTimestamp}>{formatTimestamp(item.timestamp)}</Text>
+        </View>
+      );
+    },
+    [currentUser.id],
+  );
+
+  const keyExtractor = useCallback((item: ChatMessage) => item.id, []);
+
+  const listData = useMemo(() => messages, [messages]);
+
+  return (
+    <View style={styles.container}>
+      <FlatList
+        data={listData}
+        keyExtractor={keyExtractor}
+        renderItem={renderItem}
+        contentContainerStyle={listData.length ? styles.listContent : styles.listEmpty}
+        ListEmptyComponent={<Text style={styles.emptyState}>{emptyStateText}</Text>}
+      />
+      <View style={styles.inputContainer}>
+        <TextInput
+          style={styles.input}
+          value={draft}
+          onChangeText={setDraft}
+          placeholder={placeholder}
+          multiline
+          autoCorrect
+          onSubmitEditing={sendMessage}
+          editable={!isSending}
+        />
+        <Pressable
+          accessibilityRole="button"
+          onPress={sendMessage}
+          disabled={!draft.trim() || isSending}
+          style={({ pressed }) => [
+            styles.sendButton,
+            (!draft.trim() || isSending) && styles.sendButtonDisabled,
+            pressed && !isSending ? styles.sendButtonPressed : null,
+          ]}
+        >
+          <Text style={styles.sendButtonLabel}>Envoyer</Text>
+        </Pressable>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    borderWidth: 1,
+    borderColor: '#d1d5db',
+    borderRadius: 12,
+    overflow: 'hidden',
+    backgroundColor: '#f9fafb',
+  },
+  listContent: {
+    padding: 12,
+    gap: 8,
+  },
+  listEmpty: {
+    padding: 24,
+  },
+  emptyState: {
+    textAlign: 'center',
+    color: '#6b7280',
+  },
+  messageBubble: {
+    padding: 12,
+    borderRadius: 12,
+    backgroundColor: '#e5e7eb',
+  },
+  messageBubbleSelf: {
+    backgroundColor: '#a5b4fc',
+    alignSelf: 'flex-end',
+  },
+  messageBubbleOther: {
+    backgroundColor: '#e5e7eb',
+    alignSelf: 'flex-start',
+  },
+  messageSender: {
+    fontWeight: '600',
+    color: '#111827',
+    marginBottom: 4,
+  },
+  messageText: {
+    color: '#111827',
+  },
+  messageTimestamp: {
+    marginTop: 4,
+    fontSize: 12,
+    color: '#4b5563',
+    textAlign: 'right',
+  },
+  inputContainer: {
+    flexDirection: 'row',
+    alignItems: 'flex-end',
+    padding: 12,
+    borderTopWidth: 1,
+    borderTopColor: '#d1d5db',
+    gap: 8,
+    backgroundColor: '#fff',
+  },
+  input: {
+    flex: 1,
+    minHeight: 40,
+    maxHeight: 120,
+    borderWidth: 1,
+    borderColor: '#d1d5db',
+    borderRadius: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    backgroundColor: '#f9fafb',
+    color: '#111827',
+  },
+  sendButton: {
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+    borderRadius: 8,
+    backgroundColor: '#4f46e5',
+  },
+  sendButtonDisabled: {
+    backgroundColor: '#a5b4fc',
+  },
+  sendButtonPressed: {
+    opacity: 0.85,
+  },
+  sendButtonLabel: {
+    color: '#fff',
+    fontWeight: '600',
+  },
+});

--- a/src/components/realtime/RealtimeDrawFeed.tsx
+++ b/src/components/realtime/RealtimeDrawFeed.tsx
@@ -1,0 +1,429 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { FlatList, Pressable, StyleSheet, Text, TextInput, View } from 'react-native';
+import type { ListRenderItem } from 'react-native';
+import type { Message } from 'ably';
+import { v4 as uuidv4 } from 'uuid';
+
+import { useAblyChannel } from '@/hooks/useAblyChannel';
+import type { DrawResult, DrawResultPayload, RealtimeIdentity } from '@/types/realtime';
+
+const DRAW_EVENT = 'draw-result';
+const DEFAULT_DICE = [4, 6, 8, 10, 12, 20, 100];
+
+interface RealtimeDrawFeedProps {
+  channelName: string;
+  currentUser: RealtimeIdentity;
+  historyLimit?: number;
+  diceOptions?: number[];
+  emptyStateText?: string;
+}
+
+const formatTimestamp = (timestamp: number) => {
+  const date = new Date(timestamp);
+  const hours = date.getHours().toString().padStart(2, '0');
+  const minutes = date.getMinutes().toString().padStart(2, '0');
+  return `${hours}h${minutes}`;
+};
+
+const parseDrawResult = (message: Message): DrawResult | null => {
+  if (message.name && message.name !== DRAW_EVENT) {
+    return null;
+  }
+
+  const data = message.data as Partial<DrawResultPayload> | null | undefined;
+
+  if (!data) {
+    return null;
+  }
+
+  const rolls = Array.isArray(data.rolls)
+    ? data.rolls.filter((value): value is number => typeof value === 'number')
+    : [];
+
+  const fallbackId =
+    data.id ??
+    message.id ??
+    (message.timestamp ? `${message.timestamp}-${message.connectionId ?? 'local'}` : undefined) ??
+    uuidv4();
+
+  const modifier = typeof data.modifier === 'number' ? data.modifier : undefined;
+  const total =
+    typeof data.total === 'number'
+      ? data.total
+      : rolls.reduce((sum, value) => sum + value, 0) + (modifier ?? 0);
+
+  return {
+    id: fallbackId,
+    actorId: data.actorId ?? message.clientId ?? 'unknown',
+    actorName: data.actorName ?? data.actorId ?? message.clientId ?? 'Anonyme',
+    label: data.label ?? 'Jet',
+    diceSize: data.diceSize ?? 20,
+    rolls: rolls.length ? rolls : [0],
+    modifier,
+    total,
+    timestamp: message.timestamp ?? Date.now(),
+  };
+};
+
+const clamp = (value: number, min: number, max: number) => Math.min(Math.max(value, min), max);
+
+export default function RealtimeDrawFeed({
+  channelName,
+  currentUser,
+  historyLimit = 50,
+  diceOptions = DEFAULT_DICE,
+  emptyStateText = 'Aucun tirage partagé pour le moment.',
+}: RealtimeDrawFeedProps) {
+  const [draws, setDraws] = useState<DrawResult[]>([]);
+  const [selectedDie, setSelectedDie] = useState(() => diceOptions[0] ?? 20);
+  const [diceCount, setDiceCount] = useState('1');
+  const [modifier, setModifier] = useState('0');
+  const [label, setLabel] = useState('');
+  const [isRolling, setIsRolling] = useState(false);
+
+  const handleIncoming = useCallback((message: Message) => {
+    const parsed = parseDrawResult(message);
+    if (!parsed) {
+      return;
+    }
+
+    setDraws((previous) => {
+      const existingIndex = previous.findIndex((item) => item.id === parsed.id);
+      const nextItems = existingIndex >= 0 ? [...previous] : [...previous, parsed];
+
+      if (existingIndex >= 0) {
+        nextItems[existingIndex] = parsed;
+      }
+
+      nextItems.sort((a, b) => a.timestamp - b.timestamp);
+
+      if (nextItems.length > historyLimit) {
+        return nextItems.slice(-historyLimit);
+      }
+
+      return nextItems;
+    });
+  }, [historyLimit]);
+
+  const { channel, publish, fetchHistory } = useAblyChannel(channelName, {
+    events: DRAW_EVENT,
+    onMessage: handleIncoming,
+  });
+
+  useEffect(() => {
+    if (!channel) {
+      return;
+    }
+
+    let isMounted = true;
+
+    const loadHistory = async () => {
+      try {
+        const page = await fetchHistory({ limit: historyLimit });
+        if (!page || !isMounted) {
+          return;
+        }
+
+        const history = page.items
+          .map((item) => parseDrawResult(item))
+          .filter((item): item is DrawResult => Boolean(item))
+          .sort((a, b) => a.timestamp - b.timestamp);
+
+        setDraws(history.slice(-historyLimit));
+      } catch (error) {
+        console.warn('Unable to fetch draw history from Ably', error);
+      }
+    };
+
+    loadHistory();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [channel, fetchHistory, historyLimit]);
+
+  const rollDice = useCallback(
+    () => {
+      if (isRolling) {
+        return;
+      }
+
+      const parsedCount = clamp(parseInt(diceCount, 10) || 1, 1, 10);
+      const parsedModifier = Number(modifier) || 0;
+
+      setIsRolling(true);
+
+      const rolls = Array.from({ length: parsedCount }, () =>
+        Math.floor(Math.random() * Math.max(selectedDie, 1)) + 1,
+      );
+
+      const total = rolls.reduce((sum, value) => sum + value, 0) + parsedModifier;
+
+      const payload: DrawResultPayload = {
+        id: uuidv4(),
+        actorId: currentUser.id,
+        actorName: currentUser.name,
+        label: label.trim() || `Jet de d${selectedDie}`,
+        diceSize: selectedDie,
+        rolls,
+        modifier: parsedModifier || undefined,
+        total,
+      };
+
+      publish(DRAW_EVENT, payload)
+        .catch((error) => {
+          console.warn('Unable to publish draw result via Ably', error);
+        })
+        .finally(() => {
+          setIsRolling(false);
+          setLabel('');
+        });
+    },
+    [currentUser.id, currentUser.name, diceCount, isRolling, label, modifier, publish, selectedDie],
+  );
+
+  useEffect(() => {
+    if (!diceOptions.includes(selectedDie) && diceOptions.length) {
+      setSelectedDie(diceOptions[0]);
+    }
+  }, [diceOptions, selectedDie]);
+
+  const renderItem = useCallback<ListRenderItem<DrawResult>>(
+    ({ item }) => {
+      const isOwn = item.actorId === currentUser.id;
+      const modifierLabel =
+        typeof item.modifier === 'number' && item.modifier !== 0
+          ? `${item.modifier > 0 ? '+' : '-'} ${Math.abs(item.modifier)}`
+          : null;
+
+      return (
+        <View
+          style={[
+            styles.drawCard,
+            isOwn ? styles.drawCardSelf : styles.drawCardOther,
+          ]}
+        >
+          <Text style={styles.drawLabel}>{item.label}</Text>
+          <Text style={styles.drawMeta}>
+            {item.actorName} • {item.rolls.length}d{item.diceSize}
+            {modifierLabel ? ` ${modifierLabel}` : ''}
+          </Text>
+          <Text style={styles.drawTotal}>Résultat : {item.total}</Text>
+          <Text style={styles.drawDetails}>
+            Jets : {item.rolls.join(' + ')}
+            {modifierLabel ? ` ${modifierLabel}` : ''}
+          </Text>
+          <Text style={styles.drawTimestamp}>{formatTimestamp(item.timestamp)}</Text>
+        </View>
+      );
+    },
+    [currentUser.id],
+  );
+
+  const keyExtractor = useCallback((item: DrawResult) => item.id, []);
+
+  const listData = useMemo(() => draws.slice().reverse(), [draws]);
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.controls}>
+        <Text style={styles.controlsTitle}>Partager un tirage</Text>
+        <View style={styles.diceOptionsRow}>
+          {diceOptions.map((faces) => {
+            const isSelected = faces === selectedDie;
+            return (
+              <Pressable
+                key={faces}
+                onPress={() => setSelectedDie(faces)}
+                style={({ pressed }) => [
+                  styles.diceOption,
+                  isSelected && styles.diceOptionSelected,
+                  pressed && isSelected ? styles.diceOptionPressed : null,
+                ]}
+                accessibilityRole="button"
+              >
+                <Text
+                  style={[
+                    styles.diceOptionLabel,
+                    isSelected && styles.diceOptionLabelSelected,
+                  ]}
+                >
+                  d{faces}
+                </Text>
+              </Pressable>
+            );
+          })}
+        </View>
+        <View style={styles.inputRow}>
+          <View style={styles.inputGroup}>
+            <Text style={styles.inputLabel}>Nombre de dés</Text>
+            <TextInput
+              style={styles.input}
+              value={diceCount}
+              onChangeText={setDiceCount}
+              keyboardType="numeric"
+            />
+          </View>
+          <View style={styles.inputGroup}>
+            <Text style={styles.inputLabel}>Modificateur</Text>
+            <TextInput
+              style={styles.input}
+              value={modifier}
+              onChangeText={setModifier}
+              keyboardType="numbers-and-punctuation"
+            />
+          </View>
+        </View>
+        <TextInput
+          style={styles.input}
+          placeholder="Intitulé du tirage (optionnel)"
+          value={label}
+          onChangeText={setLabel}
+        />
+        <Pressable
+          style={({ pressed }) => [
+            styles.rollButton,
+            pressed && !isRolling ? styles.rollButtonPressed : null,
+            isRolling && styles.rollButtonDisabled,
+          ]}
+          onPress={rollDice}
+          disabled={isRolling}
+        >
+          <Text style={styles.rollButtonLabel}>{isRolling ? 'Envoi…' : 'Lancer'}</Text>
+        </Pressable>
+      </View>
+
+      <FlatList
+        data={listData}
+        keyExtractor={keyExtractor}
+        renderItem={renderItem}
+        contentContainerStyle={listData.length ? styles.listContent : styles.listEmpty}
+        ListEmptyComponent={<Text style={styles.emptyState}>{emptyStateText}</Text>}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    borderWidth: 1,
+    borderColor: '#d1d5db',
+    borderRadius: 12,
+    padding: 16,
+    backgroundColor: '#f9fafb',
+    gap: 16,
+  },
+  controls: {
+    gap: 12,
+  },
+  controlsTitle: {
+    fontWeight: '600',
+    color: '#111827',
+  },
+  diceOptionsRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 8,
+  },
+  diceOption: {
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: '#d1d5db',
+    backgroundColor: '#fff',
+  },
+  diceOptionSelected: {
+    backgroundColor: '#4f46e5',
+    borderColor: '#4f46e5',
+  },
+  diceOptionPressed: {
+    opacity: 0.85,
+  },
+  diceOptionLabel: {
+    color: '#111827',
+    fontWeight: '600',
+  },
+  diceOptionLabelSelected: {
+    color: '#fff',
+  },
+  inputRow: {
+    flexDirection: 'row',
+    gap: 12,
+  },
+  inputGroup: {
+    flex: 1,
+    gap: 4,
+  },
+  inputLabel: {
+    fontSize: 12,
+    color: '#4b5563',
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: '#d1d5db',
+    borderRadius: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    backgroundColor: '#fff',
+    color: '#111827',
+  },
+  rollButton: {
+    alignSelf: 'flex-start',
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    borderRadius: 8,
+    backgroundColor: '#4f46e5',
+  },
+  rollButtonPressed: {
+    opacity: 0.85,
+  },
+  rollButtonDisabled: {
+    backgroundColor: '#a5b4fc',
+  },
+  rollButtonLabel: {
+    color: '#fff',
+    fontWeight: '600',
+  },
+  listContent: {
+    gap: 12,
+  },
+  listEmpty: {
+    paddingVertical: 24,
+  },
+  emptyState: {
+    textAlign: 'center',
+    color: '#6b7280',
+  },
+  drawCard: {
+    padding: 12,
+    borderRadius: 12,
+    backgroundColor: '#e5e7eb',
+    gap: 6,
+  },
+  drawCardSelf: {
+    backgroundColor: '#a5b4fc',
+  },
+  drawCardOther: {
+    backgroundColor: '#e5e7eb',
+  },
+  drawLabel: {
+    fontWeight: '600',
+    color: '#111827',
+  },
+  drawMeta: {
+    color: '#111827',
+  },
+  drawTotal: {
+    fontSize: 16,
+    fontWeight: '700',
+    color: '#111827',
+  },
+  drawDetails: {
+    color: '#111827',
+  },
+  drawTimestamp: {
+    fontSize: 12,
+    color: '#4b5563',
+  },
+});

--- a/src/components/realtime/RealtimeImageBroadcast.tsx
+++ b/src/components/realtime/RealtimeImageBroadcast.tsx
@@ -1,0 +1,477 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  Alert,
+  Image,
+  Pressable,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+  ScrollView,
+} from 'react-native';
+import type { Message } from 'ably';
+import { v4 as uuidv4 } from 'uuid';
+import * as ImagePicker from 'expo-image-picker';
+
+import { useAblyChannel } from '@/hooks/useAblyChannel';
+import type { ImageBroadcast, ImageBroadcastPayload, RealtimeIdentity } from '@/types/realtime';
+
+const IMAGE_EVENT = 'image-broadcast';
+
+interface RealtimeImageBroadcastProps {
+  channelName: string;
+  currentUser: RealtimeIdentity;
+  isGameMaster: boolean;
+  historyLimit?: number;
+  emptyStateText?: string;
+}
+
+const formatDateTime = (timestamp: number) => {
+  const date = new Date(timestamp);
+  const day = date.getDate().toString().padStart(2, '0');
+  const month = (date.getMonth() + 1).toString().padStart(2, '0');
+  const hours = date.getHours().toString().padStart(2, '0');
+  const minutes = date.getMinutes().toString().padStart(2, '0');
+  return `${day}/${month} ${hours}:${minutes}`;
+};
+
+const toImageBroadcast = (message: Message): ImageBroadcast | null => {
+  if (message.name && message.name !== IMAGE_EVENT) {
+    return null;
+  }
+
+  const data = message.data as Partial<ImageBroadcastPayload> | null | undefined;
+
+  if (!data) {
+    return null;
+  }
+
+  const fallbackId =
+    data.id ??
+    message.id ??
+    (message.timestamp ? `${message.timestamp}-${message.connectionId ?? 'local'}` : undefined) ??
+    uuidv4();
+
+  return {
+    id: fallbackId,
+    senderId: data.senderId ?? message.clientId ?? 'unknown',
+    senderName: data.senderName ?? data.senderId ?? message.clientId ?? 'Anonyme',
+    imageUrl: data.imageUrl,
+    base64: data.base64,
+    mimeType: data.mimeType,
+    caption: data.caption,
+    timestamp: message.timestamp ?? Date.now(),
+  };
+};
+
+const toImageSource = (broadcast: ImageBroadcast) => {
+  if (broadcast.imageUrl) {
+    return { uri: broadcast.imageUrl } as const;
+  }
+
+  if (broadcast.base64) {
+    const mimeType = broadcast.mimeType ?? 'image/jpeg';
+    return { uri: `data:${mimeType};base64,${broadcast.base64}` } as const;
+  }
+
+  return undefined;
+};
+
+export default function RealtimeImageBroadcast({
+  channelName,
+  currentUser,
+  isGameMaster,
+  historyLimit = 10,
+  emptyStateText = "Aucune image n'a encore été partagée.",
+}: RealtimeImageBroadcastProps) {
+  const [broadcasts, setBroadcasts] = useState<ImageBroadcast[]>([]);
+  const [imageUrl, setImageUrl] = useState('');
+  const [caption, setCaption] = useState('');
+  const [isBroadcasting, setIsBroadcasting] = useState(false);
+
+  const handleIncoming = useCallback((message: Message) => {
+    const parsed = toImageBroadcast(message);
+    if (!parsed) {
+      return;
+    }
+
+    setBroadcasts((previous) => {
+      const existingIndex = previous.findIndex((item) => item.id === parsed.id);
+      const nextItems = existingIndex >= 0 ? [...previous] : [...previous, parsed];
+
+      if (existingIndex >= 0) {
+        nextItems[existingIndex] = parsed;
+      }
+
+      nextItems.sort((a, b) => a.timestamp - b.timestamp);
+
+      if (nextItems.length > historyLimit) {
+        return nextItems.slice(-historyLimit);
+      }
+
+      return nextItems;
+    });
+  }, [historyLimit]);
+
+  const { channel, publish, fetchHistory } = useAblyChannel(channelName, {
+    events: IMAGE_EVENT,
+    onMessage: handleIncoming,
+  });
+
+  useEffect(() => {
+    if (!channel) {
+      return;
+    }
+
+    let isMounted = true;
+
+    const loadHistory = async () => {
+      try {
+        const page = await fetchHistory({ limit: historyLimit });
+        if (!page || !isMounted) {
+          return;
+        }
+
+        const history = page.items
+          .map((item) => toImageBroadcast(item))
+          .filter((item): item is ImageBroadcast => Boolean(item))
+          .sort((a, b) => a.timestamp - b.timestamp);
+
+        setBroadcasts(history.slice(-historyLimit));
+      } catch (error) {
+        console.warn('Unable to fetch image broadcast history from Ably', error);
+      }
+    };
+
+    loadHistory();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [channel, fetchHistory, historyLimit]);
+
+  const broadcastImage = useCallback(
+    async (content: Pick<ImageBroadcastPayload, 'imageUrl' | 'base64' | 'mimeType'>) => {
+      if (isBroadcasting) {
+        return;
+      }
+
+      if (!content.imageUrl && !content.base64) {
+        Alert.alert('Image manquante', 'Sélectionne un fichier ou fournis une URL avant de diffuser.');
+        return;
+      }
+
+      setIsBroadcasting(true);
+
+      const payload: ImageBroadcastPayload = {
+        id: uuidv4(),
+        senderId: currentUser.id,
+        senderName: currentUser.name,
+        caption: caption.trim() || undefined,
+        ...content,
+      };
+
+      try {
+        await publish(IMAGE_EVENT, payload);
+        setCaption('');
+        setImageUrl('');
+      } catch (error) {
+        console.warn('Unable to broadcast image via Ably', error);
+      } finally {
+        setIsBroadcasting(false);
+      }
+    },
+    [caption, currentUser.id, currentUser.name, isBroadcasting, publish],
+  );
+
+  const handleBroadcastUrl = useCallback(() => {
+    const trimmed = imageUrl.trim();
+    if (!trimmed) {
+      Alert.alert('URL manquante', 'Renseigne une URL publique avant de diffuser.');
+      return;
+    }
+
+    broadcastImage({ imageUrl: trimmed });
+  }, [broadcastImage, imageUrl]);
+
+  const handlePickImage = useCallback(async () => {
+    const permission = await ImagePicker.requestMediaLibraryPermissionsAsync();
+    if (!permission.granted) {
+      Alert.alert('Permission requise', "L'application a besoin de l'accès à ta galerie pour diffuser une image.");
+      return;
+    }
+
+    const result = await ImagePicker.launchImageLibraryAsync({
+      base64: true,
+      quality: 0.7,
+      mediaTypes: ImagePicker.MediaTypeOptions.Images,
+    });
+
+    if (result.canceled || !result.assets?.length) {
+      return;
+    }
+
+    const asset = result.assets[0];
+
+    if (!asset.base64) {
+      Alert.alert(
+        'Conversion impossible',
+        "Impossible de récupérer les données de l'image sélectionnée. Réessaie avec un autre fichier.",
+      );
+      return;
+    }
+
+    if (asset.base64.length > 60000) {
+      Alert.alert(
+        'Image volumineuse',
+        "L'image encodée dépasse la taille recommandée pour Ably (≈60 Ko). Réduis sa taille avant de la diffuser.",
+      );
+      return;
+    }
+
+    broadcastImage({
+      base64: asset.base64,
+      mimeType: asset.mimeType ?? 'image/jpeg',
+    });
+  }, [broadcastImage]);
+
+  const latestBroadcast = useMemo(
+    () => (broadcasts.length ? broadcasts[broadcasts.length - 1] : null),
+    [broadcasts],
+  );
+
+  const history = useMemo(
+    () => (broadcasts.length > 1 ? broadcasts.slice(0, -1).reverse() : []),
+    [broadcasts],
+  );
+
+  const renderImage = useCallback(
+    (broadcast: ImageBroadcast, variant: 'large' | 'thumbnail') => {
+      const source = toImageSource(broadcast);
+
+      if (!source) {
+        return (
+          <View style={[styles.imageFallback, variant === 'large' ? styles.imageLarge : styles.imageThumbnail]}>
+            <Text style={styles.imageFallbackText}>Image indisponible</Text>
+          </View>
+        );
+      }
+
+      return (
+        <Image
+          source={source}
+          style={variant === 'large' ? styles.imageLarge : styles.imageThumbnail}
+          resizeMode="cover"
+        />
+      );
+    },
+    [],
+  );
+
+  return (
+    <View style={styles.container}>
+      {latestBroadcast ? (
+        <View style={styles.currentBroadcast}>
+          {renderImage(latestBroadcast, 'large')}
+          <View style={styles.captionContainer}>
+            <Text style={styles.captionTitle}>{latestBroadcast.senderName}</Text>
+            {latestBroadcast.caption ? (
+              <Text style={styles.captionText}>{latestBroadcast.caption}</Text>
+            ) : null}
+            <Text style={styles.captionTimestamp}>{formatDateTime(latestBroadcast.timestamp)}</Text>
+          </View>
+        </View>
+      ) : (
+        <View style={styles.emptyBroadcast}>
+          <Text style={styles.emptyBroadcastText}>{emptyStateText}</Text>
+        </View>
+      )}
+
+      {isGameMaster ? (
+        <View style={styles.controls}>
+          <Text style={styles.controlsTitle}>Diffuser une image</Text>
+          <TextInput
+            style={styles.input}
+            placeholder="URL de l'image (https://…)"
+            value={imageUrl}
+            onChangeText={setImageUrl}
+            editable={!isBroadcasting}
+            autoCapitalize="none"
+          />
+          <TextInput
+            style={styles.input}
+            placeholder="Légende (optionnelle)"
+            value={caption}
+            onChangeText={setCaption}
+            editable={!isBroadcasting}
+          />
+          <View style={styles.controlsButtons}>
+            <Pressable
+              style={({ pressed }) => [
+                styles.actionButton,
+                pressed && !isBroadcasting ? styles.actionButtonPressed : null,
+                (isBroadcasting || !imageUrl.trim()) && styles.actionButtonDisabled,
+              ]}
+              accessibilityRole="button"
+              onPress={handleBroadcastUrl}
+              disabled={isBroadcasting || !imageUrl.trim()}
+            >
+              <Text style={styles.actionButtonLabel}>Diffuser l'URL</Text>
+            </Pressable>
+            <Pressable
+              style={({ pressed }) => [
+                styles.actionButton,
+                pressed && !isBroadcasting ? styles.actionButtonPressed : null,
+                isBroadcasting && styles.actionButtonDisabled,
+              ]}
+              accessibilityRole="button"
+              onPress={handlePickImage}
+              disabled={isBroadcasting}
+            >
+              <Text style={styles.actionButtonLabel}>Choisir dans la galerie</Text>
+            </Pressable>
+          </View>
+        </View>
+      ) : null}
+
+      {history.length ? (
+        <View style={styles.historyContainer}>
+          <Text style={styles.historyTitle}>Historique des diffusions</Text>
+          <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={styles.historyList}>
+            {history.map((item) => (
+              <View key={item.id} style={styles.historyItem}>
+                {renderImage(item, 'thumbnail')}
+                <Text numberOfLines={1} style={styles.historyCaption}>
+                  {item.caption ?? 'Sans légende'}
+                </Text>
+                <Text style={styles.historyMeta}>{formatDateTime(item.timestamp)}</Text>
+              </View>
+            ))}
+          </ScrollView>
+        </View>
+      ) : null}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    borderWidth: 1,
+    borderColor: '#d1d5db',
+    borderRadius: 12,
+    padding: 16,
+    backgroundColor: '#f9fafb',
+    gap: 16,
+  },
+  currentBroadcast: {
+    borderRadius: 12,
+    overflow: 'hidden',
+    backgroundColor: '#fff',
+  },
+  emptyBroadcast: {
+    padding: 32,
+    borderRadius: 12,
+    backgroundColor: '#fff',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  emptyBroadcastText: {
+    color: '#6b7280',
+    textAlign: 'center',
+  },
+  imageLarge: {
+    width: '100%',
+    aspectRatio: 16 / 9,
+    backgroundColor: '#e5e7eb',
+  },
+  imageThumbnail: {
+    width: 96,
+    height: 96,
+    borderRadius: 12,
+    backgroundColor: '#e5e7eb',
+  },
+  imageFallback: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: '#e5e7eb',
+  },
+  imageFallbackText: {
+    color: '#4b5563',
+    textAlign: 'center',
+    paddingHorizontal: 12,
+  },
+  captionContainer: {
+    padding: 12,
+    gap: 4,
+  },
+  captionTitle: {
+    fontWeight: '600',
+    color: '#111827',
+  },
+  captionText: {
+    color: '#111827',
+  },
+  captionTimestamp: {
+    fontSize: 12,
+    color: '#4b5563',
+  },
+  controls: {
+    gap: 12,
+  },
+  controlsTitle: {
+    fontWeight: '600',
+    color: '#111827',
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: '#d1d5db',
+    borderRadius: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    backgroundColor: '#fff',
+    color: '#111827',
+  },
+  controlsButtons: {
+    flexDirection: 'row',
+    gap: 12,
+    flexWrap: 'wrap',
+  },
+  actionButton: {
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    borderRadius: 8,
+    backgroundColor: '#4f46e5',
+  },
+  actionButtonDisabled: {
+    backgroundColor: '#a5b4fc',
+  },
+  actionButtonPressed: {
+    opacity: 0.85,
+  },
+  actionButtonLabel: {
+    color: '#fff',
+    fontWeight: '600',
+    textAlign: 'center',
+  },
+  historyContainer: {
+    gap: 8,
+  },
+  historyTitle: {
+    fontWeight: '600',
+    color: '#111827',
+  },
+  historyList: {
+    gap: 12,
+  },
+  historyItem: {
+    width: 120,
+    gap: 4,
+  },
+  historyCaption: {
+    color: '#111827',
+  },
+  historyMeta: {
+    fontSize: 12,
+    color: '#4b5563',
+  },
+});

--- a/src/components/realtime/index.ts
+++ b/src/components/realtime/index.ts
@@ -1,0 +1,3 @@
+export { default as RealtimeChat } from './RealtimeChat';
+export { default as RealtimeImageBroadcast } from './RealtimeImageBroadcast';
+export { default as RealtimeDrawFeed } from './RealtimeDrawFeed';

--- a/src/context/AblyProvider.tsx
+++ b/src/context/AblyProvider.tsx
@@ -1,0 +1,155 @@
+import React, { createContext, useContext, useEffect, useMemo, useRef, useState } from 'react';
+import { Realtime } from 'ably';
+import type { ClientOptions, Realtime as AblyRealtime, ConnectionStateChange, ConnectionState } from 'ably';
+
+interface AblyProviderProps {
+  /**
+   * API key provided by Ably. Prefer providing the key via secure configuration rather than hardcoding.
+   */
+  apiKey?: string;
+  /**
+   * Optional authentication URL if you rely on Ably token authentication.
+   */
+  authUrl?: string;
+  /**
+   * Optional client identifier forwarded to Ably to simplify presence tracking.
+   */
+  clientId?: string;
+  /**
+   * Additional options forwarded to the Realtime client. Values provided here take precedence over the shorthand props.
+   */
+  options?: ClientOptions;
+  /**
+   * Callback fired whenever the connection state updates. Useful for debugging connection lifecycle.
+   */
+  onConnectionStateChange?: (change: ConnectionStateChange) => void;
+  /**
+   * When true the connection is not opened automatically. Useful for deferred connections.
+   */
+  autoConnect?: boolean;
+  children: React.ReactNode;
+}
+
+interface AblyContextValue {
+  client: AblyRealtime | null;
+  connectionState: ConnectionState | null;
+}
+
+const AblyContext = createContext<AblyContextValue | null>(null);
+
+const DEFAULT_OPTIONS: Partial<ClientOptions> = {
+  autoConnect: true,
+  echoMessages: true,
+};
+
+function mergeClientOptions(
+  baseOptions: ClientOptions | undefined,
+  overrides: Partial<ClientOptions>,
+): ClientOptions {
+  return {
+    ...DEFAULT_OPTIONS,
+    ...baseOptions,
+    ...overrides,
+  } as ClientOptions;
+}
+
+export function AblyProvider({
+  apiKey,
+  authUrl,
+  clientId,
+  options,
+  onConnectionStateChange,
+  autoConnect = true,
+  children,
+}: AblyProviderProps) {
+  const [client, setClient] = useState<AblyRealtime | null>(null);
+  const [connectionState, setConnectionState] = useState<ConnectionState | null>(null);
+  const clientRef = useRef<AblyRealtime | null>(null);
+
+  const memoizedOptions = useMemo(() => {
+    const shorthandOverrides: Partial<ClientOptions> = {};
+
+    if (apiKey) {
+      shorthandOverrides.key = apiKey;
+    }
+
+    if (authUrl) {
+      shorthandOverrides.authUrl = authUrl;
+    }
+
+    if (clientId) {
+      shorthandOverrides.clientId = clientId;
+    }
+
+    if (autoConnect === false) {
+      shorthandOverrides.autoConnect = false;
+    }
+
+    return mergeClientOptions(options, shorthandOverrides);
+  }, [apiKey, authUrl, clientId, options, autoConnect]);
+
+  useEffect(() => {
+    if (!memoizedOptions.key && !memoizedOptions.authUrl) {
+      console.warn(
+        'AblyProvider requires either an apiKey prop or an authUrl/token strategy provided through options.',
+      );
+      return undefined;
+    }
+
+    const realtime = new Realtime(memoizedOptions);
+
+    clientRef.current = realtime;
+    setClient(realtime);
+
+    const handleConnectionChange = (change: ConnectionStateChange) => {
+      setConnectionState(change.current);
+      if (onConnectionStateChange) {
+        onConnectionStateChange(change);
+      }
+    };
+
+    realtime.connection.on(handleConnectionChange);
+
+    if (memoizedOptions.autoConnect !== false) {
+      realtime.connect();
+    }
+
+    return () => {
+      realtime.connection.off(handleConnectionChange);
+      realtime.close();
+      clientRef.current = null;
+      setClient(null);
+      setConnectionState(null);
+    };
+  }, [memoizedOptions, onConnectionStateChange]);
+
+  const value = useMemo<AblyContextValue>(
+    () => ({
+      client,
+      connectionState,
+    }),
+    [client, connectionState],
+  );
+
+  return <AblyContext.Provider value={value}>{children}</AblyContext.Provider>;
+}
+
+export function useAblyClient(): AblyRealtime {
+  const context = useContext(AblyContext);
+
+  if (!context?.client) {
+    throw new Error('useAblyClient must be used within an AblyProvider.');
+  }
+
+  return context.client;
+}
+
+export function useAblyConnectionState() {
+  const context = useContext(AblyContext);
+
+  if (!context) {
+    throw new Error('useAblyConnectionState must be used within an AblyProvider.');
+  }
+
+  return context.connectionState;
+}

--- a/src/hooks/useAblyChannel.ts
+++ b/src/hooks/useAblyChannel.ts
@@ -1,0 +1,165 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import type {
+  Message,
+  PresenceMessage,
+  RealtimeChannel,
+  ChannelOptions,
+  ChannelStateChange,
+} from 'ably';
+import { useAblyClient } from '@/context/AblyProvider';
+
+export interface UseAblyChannelOptions {
+  /**
+   * Forward channel configuration to Ably. Use `useMemo` when providing an object literal to avoid needless re-subscriptions.
+   */
+  channelOptions?: ChannelOptions;
+  /**
+   * Subscribe to one or multiple message events.
+   */
+  events?: string | string[];
+  /**
+   * Called whenever the channel receives a message for the subscribed events.
+   */
+  onMessage?: (message: Message) => void;
+  /**
+   * Called whenever a presence event is emitted by the channel.
+   */
+  onPresenceUpdate?: (presence: PresenceMessage) => void;
+  /**
+   * Fired for channel lifecycle updates.
+   */
+  onStateChange?: (change: ChannelStateChange) => void;
+  /**
+   * Avoids detaching the channel on unmount when set to true. Useful when several components share the same channel.
+   */
+  retainOnUnmount?: boolean;
+  /**
+   * Skip subscription logic when the component should not interact with the channel yet.
+   */
+  skip?: boolean;
+}
+
+const toArray = (input?: string | string[]) => {
+  if (!input) {
+    return undefined;
+  }
+
+  return Array.isArray(input) ? input : [input];
+};
+
+const detachChannel = (channel: RealtimeChannel) => {
+  try {
+    channel.detach();
+  } catch (error) {
+    console.warn('Failed to detach Ably channel', error);
+  }
+};
+
+export function useAblyChannel(
+  channelName: string,
+  {
+    channelOptions,
+    events,
+    onMessage,
+    onPresenceUpdate,
+    onStateChange,
+    retainOnUnmount = false,
+    skip = false,
+  }: UseAblyChannelOptions = {},
+) {
+  const client = useAblyClient();
+  const [channel, setChannel] = useState<RealtimeChannel | null>(null);
+
+  const eventsArray = useMemo(() => toArray(events), [events]);
+
+  useEffect(() => {
+    if (skip) {
+      return;
+    }
+
+    const ablyChannel = client.channels.get(channelName, channelOptions);
+
+    const handleChannelState = (change: ChannelStateChange) => {
+      onStateChange?.(change);
+    };
+
+    ablyChannel.on(handleChannelState);
+
+    setChannel(ablyChannel);
+
+    const listener = (message: Message) => {
+      onMessage?.(message);
+    };
+
+    if (onMessage) {
+      if (eventsArray?.length) {
+        eventsArray.forEach((eventName) => ablyChannel.subscribe(eventName, listener));
+      } else {
+        ablyChannel.subscribe(listener);
+      }
+    }
+
+    return () => {
+      ablyChannel.off(handleChannelState);
+
+      if (onMessage) {
+        if (eventsArray?.length) {
+          eventsArray.forEach((eventName) => ablyChannel.unsubscribe(eventName, listener));
+        } else {
+          ablyChannel.unsubscribe(listener);
+        }
+      }
+
+      if (!retainOnUnmount) {
+        detachChannel(ablyChannel);
+      }
+    };
+  }, [channelName, channelOptions, client, eventsArray, onMessage, onStateChange, retainOnUnmount, skip]);
+
+  useEffect(() => {
+    if (!channel || skip || !onPresenceUpdate) {
+      return;
+    }
+
+    const presenceListener = (presence: PresenceMessage) => {
+      onPresenceUpdate(presence);
+    };
+
+    channel.presence.subscribe(presenceListener);
+
+    return () => {
+      channel.presence.unsubscribe(presenceListener);
+    };
+  }, [channel, onPresenceUpdate, skip]);
+
+  const publish = useCallback(
+    async (eventName: string, data: unknown) => {
+      if (!channel) {
+        throw new Error('Attempted to publish to a channel that is not ready.');
+      }
+
+      await channel.publish(eventName, data);
+    },
+    [channel],
+  );
+
+  const fetchHistory = useCallback(
+    async (params?: Parameters<RealtimeChannel['history']>[0]) => {
+      if (!channel) {
+        throw new Error('Attempted to read history on a channel that is not ready.');
+      }
+
+      return channel.history(params);
+    },
+    [channel],
+  );
+
+  return useMemo(
+    () => ({
+      channel,
+      publish,
+      fetchHistory,
+    }),
+    [channel, fetchHistory, publish],
+  );
+}

--- a/src/types/realtime.ts
+++ b/src/types/realtime.ts
@@ -1,0 +1,44 @@
+export interface RealtimeIdentity {
+  id: string;
+  name: string;
+}
+
+export interface ChatMessagePayload {
+  id: string;
+  text: string;
+  senderId: string;
+  senderName?: string;
+}
+
+export interface ChatMessage extends ChatMessagePayload {
+  timestamp: number;
+}
+
+export interface ImageBroadcastPayload {
+  id: string;
+  senderId: string;
+  senderName?: string;
+  imageUrl?: string;
+  base64?: string;
+  mimeType?: string;
+  caption?: string;
+}
+
+export interface ImageBroadcast extends ImageBroadcastPayload {
+  timestamp: number;
+}
+
+export interface DrawResultPayload {
+  id: string;
+  actorId: string;
+  actorName?: string;
+  label: string;
+  diceSize: number;
+  rolls: number[];
+  modifier?: number;
+  total: number;
+}
+
+export interface DrawResult extends DrawResultPayload {
+  timestamp: number;
+}


### PR DESCRIPTION
## Summary
- add an Ably provider, hook, and shared realtime types for managing the connection lifecycle
- implement chat, image broadcast, and draw feed UI components that synchronise data over Ably channels
- document Ably setup guidance and add the Ably SDK dependency

## Testing
- npx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68cdbe5bf010832e8d195647152f54d3